### PR TITLE
Add net-tools to installed dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## UPCOMING
+
+## `v2019_10_04_1`
+
+* Add `net-tools` to pre-installed tools.
+https://github.com/bitrise-io/android/pull/241
+
 ## `v2019_08_11_1`
 
 * new preinstalled packages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq
 # Dependencies to execute Android builds
 RUN dpkg --add-architecture i386
 RUN apt-get update -qq
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386 net-tools
 
 
 # ------------------------------------------------------


### PR DESCRIPTION
AVD internally uses `netstat` command. This PR adds `net-tools` to dependencies so that using AVD won't make build fail.