### PR TITLE
New preinstalled package: build-tools-29.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UPCOMING
 
+## `v2020_01_30_1`
+
+* new preinstalled package: `build-tools-29.0.3`
+ https://github.com/bitrise-docker/android/pull/279
+
 ## `v2019_10_04_1`
 
 * Add `net-tools` to pre-installed tools.

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN yes | sdkmanager \
     "platforms;android-19" \
     "platforms;android-17" \
     "platforms;android-15" \
+    "build-tools;29.0.3" \
     "build-tools;29.0.2" \
     "build-tools;29.0.1" \
     "build-tools;29.0.0" \
@@ -186,5 +187,5 @@ RUN cd /opt \
 # Cleaning
 RUN apt-get clean
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2019_08_11_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_01_30_1
 CMD bitrise -version


### PR DESCRIPTION
### Pull Request Checklist

Check/accept these:

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I've updated the version in the Dockerfile
- [x] I've updated the CHANGELOG.md
- [x] I've provided a link or explanation below which describes the changes in the tool itself
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

https://developer.android.com/studio/releases/build-tools