### PR TITLE
Deprecated SDK Tools replaced with Command line Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UPCOMING
 
+## `v2020_06_14_1`
+
+* Deprecated SDK tools replaced with Command line Tools: https://github.com/bitrise-docker/android/pull/300
+
 ## `v2020_04_17_1`
 * `Gradle updated to 6.3`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cd /opt \
     && unzip -q android-commandline-tools.zip -d ${ANDROID_HOME}/cmdline-tools \
     && rm android-commandline-tools.zip
 
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools/bin
+ENV PATH ${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools/bin
 
 # ------------------------------------------------------
 # --- Install Android SDKs and other build packages
@@ -44,7 +44,7 @@ RUN yes | sdkmanager  --licenses
 RUN touch /root/.android/repositories.cfg
 
 # Platform tools
-RUN sdkmanager "emulator" "cmdline-tools;2.0" "platform-tools"
+RUN yes | sdkmanager "emulator" "platform-tools"
 
 # SDKs
 # Please keep these in descending order!

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 l
 
 RUN cd /opt \
     && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip -O android-commandline-tools.zip \
-    && mkdir -p ${ANDROID_HOME}/cmdline-tools \
-    && unzip -q android-commandline-tools.zip -d ${ANDROID_HOME}/cmdline-tools \
+    && mkdir -p ${ANDROID_HOME}/cmdline-tools/latest \
+    && unzip -q android-commandline-tools.zip -d ${ANDROID_HOME}/cmdline-tools/latest \
     && rm android-commandline-tools.zip
 
-ENV PATH ${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools/bin
+ENV PATH ${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/latest/tools/bin
 
 # ------------------------------------------------------
 # --- Install Android SDKs and other build packages
@@ -44,7 +44,7 @@ RUN yes | sdkmanager  --licenses
 RUN touch /root/.android/repositories.cfg
 
 # Emulator and Platform tools
-RUN yes | sdkmanager "emulator" "platform-tools"
+RUN yes | sdkmanager "cmdline-tools;latest" "emulator" "platform-tools"
 
 # SDKs
 # Please keep these in descending order!

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 l
 # --- Download Android Command line Tools into $ANDROID_HOME
 
 RUN cd /opt \
-    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip -O android-commandline-tools.zip \
-    && mkdir -p ${ANDROID_HOME}/cmdline-tools/latest \
-    && unzip -q android-commandline-tools.zip -d ${ANDROID_HOME}/cmdline-tools/latest \
+    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O android-commandline-tools.zip \
+    && mkdir -p ${ANDROID_HOME}/cmdline-tools \
+    && unzip -q android-commandline-tools.zip -d ${ANDROID_HOME}/cmdline-tools \
     && rm android-commandline-tools.zip
 
-ENV PATH ${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/latest/tools/bin
+ENV PATH ${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools/bin
 
 # ------------------------------------------------------
 # --- Install Android SDKs and other build packages
@@ -44,7 +44,7 @@ RUN yes | sdkmanager  --licenses
 RUN touch /root/.android/repositories.cfg
 
 # Emulator and Platform tools
-RUN yes | sdkmanager "cmdline-tools;latest" "emulator" "platform-tools"
+RUN yes | sdkmanager "emulator" "platform-tools"
 
 # SDKs
 # Please keep these in descending order!

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,7 +174,7 @@ RUN npm install -g firebase-tools
 # Required for Android ARM Emulator
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libqt5widgets5
 ENV QT_QPA_PLATFORM offscreen
-ENV LD_LIBRARY_PATH ${ANDROID_HOME}/tools/lib64:${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib
+ENV LD_LIBRARY_PATH ${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib
 
 # -------------------------------------------------------
 # Tools to parse apk/aab info in deploy-to-bitrise-io step

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN yes | sdkmanager  --licenses
 
 RUN touch /root/.android/repositories.cfg
 
-# Platform tools
+# Emulator and Platform tools
 RUN yes | sdkmanager "emulator" "platform-tools"
 
 # SDKs

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 l
 
 
 # ------------------------------------------------------
-# --- Download Android SDK tools into $ANDROID_HOME
+# --- Download Android Command line Tools into $ANDROID_HOME
 
 RUN cd /opt \
-    && wget -q https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O android-sdk-tools.zip \
-    && unzip -q android-sdk-tools.zip -d ${ANDROID_HOME} \
-    && rm android-sdk-tools.zip
+    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip -O android-commandline-tools.zip \
+    && mkdir -p ${ANDROID_HOME}/cmdline-tools \
+    && unzip -q android-commandline-tools.zip -d ${ANDROID_HOME}/cmdline-tools \
+    && rm android-commandline-tools.zip
 
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools/bin
 
 # ------------------------------------------------------
 # --- Install Android SDKs and other build packages
@@ -43,7 +44,7 @@ RUN yes | sdkmanager  --licenses
 RUN touch /root/.android/repositories.cfg
 
 # Platform tools
-RUN sdkmanager "emulator" "tools" "platform-tools"
+RUN sdkmanager "emulator" "cmdline-tools;2.0" "platform-tools"
 
 # SDKs
 # Please keep these in descending order!
@@ -191,5 +192,5 @@ RUN cd /opt \
 # Cleaning
 RUN apt-get clean
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_04_17_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_06_14_1
 CMD bitrise -version

--- a/system_report.sh
+++ b/system_report.sh
@@ -75,7 +75,7 @@ echo " * SDK packages:"
 if [[ ! -z "${BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS}" ]] ; then
     echo " (!) Version check not available on this Stack / in this image"
 else
-    grep ^Pkg.Revision ${ANDROID_HOME}/cmdline-tools/latest/tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Command line Tools version: {}"
+    grep ^Pkg.Revision ${ANDROID_HOME}/cmdline-tools//tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Command line Tools version: {}"
     grep ^Pkg.Revision ${ANDROID_HOME}/platform-tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Platform Tools version: {}"
     grep ^Pkg.Revision ${ANDROID_HOME}/emulator/source.properties | cut -d= -f 2 | xargs -I {} echo "* Emulator version: {}"
 fi

--- a/system_report.sh
+++ b/system_report.sh
@@ -75,7 +75,7 @@ echo " * SDK packages:"
 if [[ ! -z "${BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS}" ]] ; then
     echo " (!) Version check not available on this Stack / in this image"
 else
-    grep ^Pkg.Revision ${ANDROID_HOME}/cmdline-tools/tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Command line Tools version: {}"
+    grep ^Pkg.Revision ${ANDROID_HOME}/cmdline-tools/latest/tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Command line Tools version: {}"
     grep ^Pkg.Revision ${ANDROID_HOME}/platform-tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Platform Tools version: {}"
     grep ^Pkg.Revision ${ANDROID_HOME}/emulator/source.properties | cut -d= -f 2 | xargs -I {} echo "* Emulator version: {}"
 fi

--- a/system_report.sh
+++ b/system_report.sh
@@ -75,7 +75,7 @@ echo " * SDK packages:"
 if [[ ! -z "${BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS}" ]] ; then
     echo " (!) Version check not available on this Stack / in this image"
 else
-    grep ^Pkg.Revision ${ANDROID_HOME}/tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* SDK Tools version: {}"
+    grep ^Pkg.Revision ${ANDROID_HOME}/cmdline-tools/tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Command line Tools version: {}"
     grep ^Pkg.Revision ${ANDROID_HOME}/platform-tools/source.properties | cut -d= -f 2 | xargs -I {} echo "* Platform Tools version: {}"
     grep ^Pkg.Revision ${ANDROID_HOME}/emulator/source.properties | cut -d= -f 2 | xargs -I {} echo "* Emulator version: {}"
 fi


### PR DESCRIPTION
### Pull Request Checklist

Check/accept these:

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I've updated the version in the Dockerfile
- [x] I've updated the CHANGELOG.md
- [x] I've provided a link or explanation below which describes the changes in the tool itself
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

https://developer.android.com/studio/releases/sdk-tools