### PR TITLE
[IN-1719]: revert java 11 0 upgrade to not break gradle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV ANDROID_HOME /opt/android-sdk-linux
 # ------------------------------------------------------
 # --- Install required tools
 
-RUN add-apt-repository ppa:openjdk-r/ppa
 RUN apt-get update -qq
 
 # Base (non android specific) tools
@@ -15,12 +14,8 @@ RUN apt-get update -qq
 # Dependencies to execute Android builds
 RUN dpkg --add-architecture i386
 RUN apt-get update -qq
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jdk libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386 net-tools
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386 net-tools
 
-# Keystore format has changed since JAVA 8 https://bugs.launchpad.net/ubuntu/+source/openjdk-9/+bug/1743139
-RUN mv /etc/ssl/certs/java/cacerts /etc/ssl/certs/java/cacerts.old \
-    && keytool -importkeystore -destkeystore /etc/ssl/certs/java/cacerts -deststoretype jks -deststorepass changeit -srckeystore /etc/ssl/certs/java/cacerts.old -srcstoretype pkcs12 -srcstorepass changeit \
-    && rm /etc/ssl/certs/java/cacerts.old
 
 # ------------------------------------------------------
 # --- Download Android Command line Tools into $ANDROID_HOME
@@ -44,7 +39,7 @@ ENV PATH ${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/to
 # Accept licenses before installing components, no need to echo y for each component
 # License is valid for all the standard components in versions installed from this file
 # Non-standard components: MIPS system images, preview versions, GDK (Google Glass) and Android Google TV require separate licenses, not accepted there
-RUN yes | sdkmanager --licenses
+RUN yes | sdkmanager  --licenses
 
 RUN touch /root/.android/repositories.cfg
 


### PR DESCRIPTION
This reverts commit c2ce84fc160150c326c1db84a9dc3df34360ef02.

### Pull Request Checklist

Check/accept these:

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I've updated the version in the Dockerfile
- [ ] I've updated the CHANGELOG.md
- [ ] I've provided a link or explanation below which describes the changes in the tool itself
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

`Copy or link the tool's changelog here`
