### PR TITLE
[IN-1842] Install Java 11 but keep Java 8 as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UPCOMING
 
+## `v2020+09_30_1`
+
+* Java 11 preinstalled
+
 ## `v2020_06_14_1`
 
 * Deprecated SDK tools replaced with Command line Tools: https://github.com/bitrise-docker/android/pull/300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UPCOMING
 
-## `v2020+09_30_1`
+## `v2020_09_30_1`
 
 * Java 11 preinstalled
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,8 +115,6 @@ RUN yes | sdkmanager \
 # ------------------------------------------------------
 # --- Install Gradle from PPA
 
-RUN java -version
-
 # Gradle PPA
 ENV GRADLE_VERSION=6.3
 ENV PATH=$PATH:"/opt/gradle/gradle-6.3/bin/"
@@ -133,8 +131,6 @@ RUN apt-get purge maven maven2 \
  && apt-get update \
  && apt-get -y install maven \
  && mvn --version
-
-RUN java -version
 
 # Reselect JAVA 8  as default
 RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,8 @@ RUN apt-get purge maven maven2 \
  && apt-get -y install maven \
  && mvn --version
 
+# Reselect JAVA 8  as default
+RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64
 
 # ------------------------------------------------------
 # --- Pre-install Ionic and Cordova CLIs

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN mv /etc/ssl/certs/java/cacerts /etc/ssl/certs/java/cacerts.old \
 
 # Select JAVA 8  as default
 RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64
+RUN sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
 
 # ------------------------------------------------------
 # --- Download Android Command line Tools into $ANDROID_HOME
@@ -134,6 +135,7 @@ RUN apt-get purge maven maven2 \
 
 # Reselect JAVA 8  as default
 RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64
+RUN sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # ------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,8 @@ RUN yes | sdkmanager \
 # ------------------------------------------------------
 # --- Install Gradle from PPA
 
+RUN java -version
+
 # Gradle PPA
 ENV GRADLE_VERSION=6.3
 ENV PATH=$PATH:"/opt/gradle/gradle-6.3/bin/"
@@ -131,6 +133,8 @@ RUN apt-get purge maven maven2 \
  && apt-get update \
  && apt-get -y install maven \
  && mvn --version
+
+RUN java -version
 
 # Reselect JAVA 8  as default
 RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,7 @@ RUN apt-get purge maven maven2 \
 
 # Reselect JAVA 8  as default
 RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # ------------------------------------------------------
 # --- Pre-install Ionic and Cordova CLIs

--- a/Dockerfile-pinned
+++ b/Dockerfile-pinned
@@ -3,6 +3,6 @@
 # is pre-cached on https://www.bitrise.io/ Linux/Android Virtual Machines.
 # Read more about how versions are handled in the README.md
 
-FROM quay.io/bitriseio/android:alpha-v2020_08_20-02_20-b2196
+FROM quay.io/bitriseio/android:alpha-v2020_09_03-02_22-b2231
 
 CMD bitrise --version

--- a/system_report.sh
+++ b/system_report.sh
@@ -33,6 +33,12 @@ fi
 echo "========================================"
 echo
 
+echo "=== Java ==============================="
+
+echo "* JAVA_HOME: $JAVA_HOME"
+ver_line="$( java -version 2>&1  | head -n 1)" ;          echo "* Java: $ver_line"
+ver_line="$( javac -version 2>&1  | head -n 1)" ;         echo "* Javac: $ver_line"
+
 echo
 echo "=== Google Cloud SDK components ========"
 if [[ ! -z "$BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS" ]] ; then

--- a/system_report.sh
+++ b/system_report.sh
@@ -39,6 +39,9 @@ echo "* JAVA_HOME: $JAVA_HOME"
 ver_line="$( java -version 2>&1  | head -n 1)" ;          echo "* Java: $ver_line"
 ver_line="$( javac -version 2>&1  | head -n 1)" ;         echo "* Javac: $ver_line"
 
+echo "========================================"
+echo
+
 echo
 echo "=== Google Cloud SDK components ========"
 if [[ ! -z "$BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS" ]] ; then


### PR DESCRIPTION
### Pull Request Checklist

Check/accept these:

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I've updated the version in the Dockerfile
- [ ] I've updated the CHANGELOG.md
- [ ] I've provided a link or explanation below which describes the changes in the tool itself
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

`Copy or link the tool's changelog here`
