### PR TITLE
Add Build tools 30.0.2. Replace ANDROID_HOME with ANDROID_SDK_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## UPCOMING
 
+## `v2020_09_22_1`
+
+* new preinstalled package: `build-tools-30.0.2`
+* Deprecated ANDROID_HOME replaced with ANDROID_SDK_ROOT
+
+https://github.com/bitrise-docker/android/pull/318
+
 ## `v2020_06_14_1`
 
 * Deprecated SDK tools replaced with Command line Tools: https://github.com/bitrise-docker/android/pull/300

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/bitriseio/bitrise-base:alpha
 
+ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
+# Preserved for backwards compatibility
 ENV ANDROID_HOME /opt/android-sdk-linux
-
 
 # ------------------------------------------------------
 # --- Install required tools
@@ -18,15 +19,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 l
 
 
 # ------------------------------------------------------
-# --- Download Android Command line Tools into $ANDROID_HOME
+# --- Download Android Command line Tools into $ANDROID_SDK_ROOT
 
 RUN cd /opt \
     && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O android-commandline-tools.zip \
-    && mkdir -p ${ANDROID_HOME}/cmdline-tools \
-    && unzip -q android-commandline-tools.zip -d ${ANDROID_HOME}/cmdline-tools \
+    && mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && unzip -q android-commandline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
     && rm android-commandline-tools.zip
 
-ENV PATH ${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/tools/bin
+ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin
 
 # ------------------------------------------------------
 # --- Install Android SDKs and other build packages
@@ -66,6 +67,7 @@ RUN yes | sdkmanager \
     "platforms;android-19" \
     "platforms;android-17" \
     "platforms;android-15" \
+    "build-tools;30.0.2" \
     "build-tools;30.0.0" \
     "build-tools;29.0.3" \
     "build-tools;29.0.2" \
@@ -177,7 +179,7 @@ RUN npm install -g firebase-tools
 # Required for Android ARM Emulator
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libqt5widgets5
 ENV QT_QPA_PLATFORM offscreen
-ENV LD_LIBRARY_PATH ${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib
+ENV LD_LIBRARY_PATH ${ANDROID_SDK_ROOT}/emulator/lib64:${ANDROID_SDK_ROOT}/emulator/lib64/qt/lib
 
 # -------------------------------------------------------
 # Tools to parse apk/aab info in deploy-to-bitrise-io step
@@ -195,5 +197,5 @@ RUN cd /opt \
 # Cleaning
 RUN apt-get clean
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_06_14_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_09_22_1
 CMD bitrise -version


### PR DESCRIPTION
### Pull Request Checklist

Check/accept these:

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I've updated the version in the Dockerfile
- [x] I've updated the CHANGELOG.md
- [x] I've provided a link or explanation below which describes the changes in the tool itself
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

https://developer.android.com/studio/command-line/variables#envar
https://developer.android.com/studio/releases/build-tools (version 30.0.2 not yet added at the time of writing)
