### PR TITLE
Update preinstalled packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## UPCOMING
 
+## `v2020_12_15_1`
+
+* new preinstalled package `build-tools-30.0.3`
+* bundletool updated to 1.4.0.jar
+* aapt2 updated to 4.1.1-6503028
+* commandline tools updated to 6858069
+
 ## `v2020_09_30_1`
 
 * Java 11 preinstalled

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/j
 # --- Download Android Command line Tools into $ANDROID_SDK_ROOT
 
 RUN cd /opt \
-    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O android-commandline-tools.zip \
+    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O android-commandline-tools.zip \
     && mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
     && unzip -q android-commandline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
     && rm android-commandline-tools.zip
@@ -75,6 +75,7 @@ RUN yes | sdkmanager \
     "platforms;android-19" \
     "platforms;android-17" \
     "platforms;android-15" \
+    "build-tools;30.0.3" \
     "build-tools;30.0.2" \
     "build-tools;30.0.0" \
     "build-tools;29.0.3" \
@@ -197,9 +198,9 @@ ENV LD_LIBRARY_PATH ${ANDROID_SDK_ROOT}/emulator/lib64:${ANDROID_SDK_ROOT}/emula
 # Tools to parse apk/aab info in deploy-to-bitrise-io step
 ENV APKINFO_TOOLS /opt/apktools
 RUN mkdir ${APKINFO_TOOLS}
-RUN wget -q https://github.com/google/bundletool/releases/download/0.10.3/bundletool-all-0.10.3.jar -O ${APKINFO_TOOLS}/bundletool.jar
+RUN wget -q https://github.com/google/bundletool/releases/download/1.4.0/bundletool-all-1.4.0.jar -O ${APKINFO_TOOLS}/bundletool.jar
 RUN cd /opt \
-    && wget -q https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/3.5.0-5435860/aapt2-3.5.0-5435860-linux.jar -O aapt2.jar \
+    && wget -q https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/4.1.1-6503028/aapt2-4.1.1-6503028-linux.jar -O aapt2.jar \
     && unzip -q aapt2.jar aapt2 -d ${APKINFO_TOOLS} \
     && rm aapt2.jar
 
@@ -209,5 +210,5 @@ RUN cd /opt \
 # Cleaning
 RUN apt-get clean
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_09_22_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_12_15_1
 CMD bitrise -version

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,11 @@ RUN sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/j
 RUN cd /opt \
     && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O android-commandline-tools.zip \
     && mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
-    && unzip -q android-commandline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
-    && rm android-commandline-tools.zip
+    && unzip -q android-commandline-tools.zip -d /tmp/ \
+    && mv /tmp/cmdline-tools/ ${ANDROID_SDK_ROOT}/cmdline-tools/latest \
+    && rm android-commandline-tools.zip && ls -la ${ANDROID_SDK_ROOT}/cmdline-tools/latest/
 
-ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin
+ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin
 
 # ------------------------------------------------------
 # --- Install Android SDKs and other build packages


### PR DESCRIPTION
* new preinstalled package `build-tools-30.0.3`
* bundletool updated to 1.4.0.jar
* aapt2 updated to 4.1.1-6503028
* commandline tools updated to 6858069

### Pull Request Checklist

Check/accept these:

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I've updated the version in the Dockerfile
- [x] I've updated the CHANGELOG.md
- [x] I've provided a link or explanation below which describes the changes in the tool itself
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

https://developer.android.com/studio/releases/cmdline-tools
https://github.com/google/bundletool/releases
https://developer.android.com/studio/releases/build-tools
https://developer.android.com/studio/releases/gradle-plugin