### PR TITLE
[IN-2902] Set Java 11 as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_09_29`
+* `Set Java 11 as default`
+
 ## `v2020_12_15_1`
 
 * new preinstalled package `build-tools-30.0.3`

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN mv /etc/ssl/certs/java/cacerts /etc/ssl/certs/java/cacerts.old \
     && keytool -importkeystore -destkeystore /etc/ssl/certs/java/cacerts -deststoretype jks -deststorepass changeit -srckeystore /etc/ssl/certs/java/cacerts.old -srcstoretype pkcs12 -srcstorepass changeit \
     && rm /etc/ssl/certs/java/cacerts.old
 
-# Select JAVA 8  as default
-RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64
-RUN sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+# Select JAVA 11  as default
+RUN sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+RUN sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
 # ------------------------------------------------------
 # --- Download Android Command line Tools into $ANDROID_SDK_ROOT
@@ -137,10 +137,7 @@ RUN apt-get purge maven maven2 \
  && apt-get -y install maven \
  && mvn --version
 
-# Reselect JAVA 8  as default
-RUN sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64
-RUN sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 
 # ------------------------------------------------------
 # --- Pre-install Ionic and Cordova CLIs
@@ -211,5 +208,5 @@ RUN cd /opt \
 # Cleaning
 RUN apt-get clean
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2020_12_15_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID v2021_09_29
 CMD bitrise -version


### PR DESCRIPTION
### Pull Request Checklist

Check/accept these:

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I've updated the version in the Dockerfile
- [ ] I've updated the CHANGELOG.md
- [ ] I've provided a link or explanation below which describes the changes in the tool itself
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

`Copy or link the tool's changelog here`
